### PR TITLE
fix: change license to CC BY-ND 4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,14 @@
-Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
 Copyright (C) 2021 DEVSTRONS'
 
 You are free to:
 Share — copy and redistribute the material in any medium or format
-Adapt — remix, transform, and build upon the material for any purpose, even commercially.
+for any purpose, even commercially.
 
 Under the following terms:
-
 Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
 
-ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+NoDerivatives — If you remix, transform, or build upon the material, you may not distribute the modified material.
 
 Notices:
 
@@ -17,4 +16,4 @@ You do not have to comply with the license for elements of the material in the p
 No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
 
 For more details:
-https://creativecommons.org/licenses/by-sa/4.0/
+https://creativecommons.org/licenses/by-nd/4.0/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We've written a non-exhaustive list of what you can and cannot do.
 | :heavy_check_mark: Use the [provided branding assets](https://github.com/devstrons/artwork) | :x: Create your own versions of the [original files](https://github.com/devstrons/artwork). |                             |
 | :heavy_check_mark: Use the original colors                  |               :x: Use our branding assets for your own use-case without permission
 | :heavy_check_mark: Use our branding assets commercially      |               :x: Sell our branding assets (for your own use-case) without permission
-| :heavy_check_mark: Use the current branding assets size      |               :x: Violate the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license guidelines
+| :heavy_check_mark: Use the current branding assets size      |               :x: Violate the [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) license guidelines
 | :heavy_check_mark: Use our branding assets for new community partnerships with DEVSTRONS'                     |               :x: Mix/integrate your logo with our branding assets
 
 ## 📧 Contact


### PR DESCRIPTION
Things added/changed:

- Change the license to CC BY-ND 4.0.
  - Our guidelines actually violate the CC BY-SA 4.0 license guidelines, so let's use the CC BY-ND 4.0 instead.
  - CC: @amino19, @JOS-RE.
